### PR TITLE
Fix: empty user streaks cmd

### DIFF
--- a/app/src/main/java/bot/cmd/DefineCommand.java
+++ b/app/src/main/java/bot/cmd/DefineCommand.java
@@ -6,7 +6,6 @@ import bot.entity.word.JournalWord;
 import bot.service.UserService;
 import bot.service.WordCacheService;
 import bot.view.WordCacheView;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -126,7 +125,7 @@ public class DefineCommand extends BotCommand {
             int selectedNo = Integer.parseInt(selected);
             String discordId = event.getUser().getId();
             String numberDisplay = "**#" + (selectedNo + 1) + "**";
-
+            User user = userService.getUser(discordId);
             JournalWord journalWord =
                     JournalWord.builder()
                             .word(word)
@@ -137,30 +136,6 @@ public class DefineCommand extends BotCommand {
                             .definitionIndex(selectedNo)
                             .quality(-1) // -1 since this word has never been graded before
                             .build();
-
-            // If the user was not found
-            if (!userService.userExists(discordId)) {
-                User user =
-                        User.builder()
-                                .discordId(event.getUser().getId())
-                                .words(Collections.singletonList(journalWord))
-                                .build();
-
-                userService.createUser(user);
-                userService.updateWordSuperMemo(
-                        discordId, journalWord.getWord(), journalWord.getDefinitionIndex(), 0);
-
-                event.reply(
-                                "I saved the word `"
-                                        + word
-                                        + "` to your journal with"
-                                        + " the "
-                                        + numberDisplay
-                                        + " definition! :blue_book:")
-                        .setEphemeral(true)
-                        .queue();
-                return;
-            }
 
             if (userService.hasJournalWord(discordId, word, journalWord.getDefinitionIndex())) {
                 event.reply(

--- a/app/src/main/java/bot/service/UserService.java
+++ b/app/src/main/java/bot/service/UserService.java
@@ -35,6 +35,15 @@ public class UserService {
     }
 
     public User getUser(@NonNull String discordId) {
+        boolean exists = userExists(discordId);
+
+        if (!exists) {
+            User user = User.builder().discordId(discordId).words(Collections.emptyList()).build();
+
+            createUser(user);
+            return user;
+        }
+
         return userRepository.findUserByDiscordId(discordId);
     }
 

--- a/app/src/main/java/bot/service/UserService.java
+++ b/app/src/main/java/bot/service/UserService.java
@@ -34,6 +34,12 @@ public class UserService {
         userRepository.save(user);
     }
 
+    /**
+     * Gets an instance of the user <b>or creates a new one</b>.
+     *
+     * @param discordId The discord ID of the user to look for
+     * @return An existing or new instance of the user from the database
+     */
     public User getUser(@NonNull String discordId) {
         boolean exists = userExists(discordId);
 


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] All of the code is easily understood.
- [x] There is no redundant or duplicate code.

## Describe your changes
This PR aims to fix a bug where NPEs are thrown when fetching user data using a Discord ID that hasn't been stored in the database.

## Issue number
None