### PR TITLE
Assigning the member role to new members in the Learn English server

### DIFF
--- a/app/src/main/java/bot/App.java
+++ b/app/src/main/java/bot/App.java
@@ -1,6 +1,7 @@
 package bot;
 
 import bot.cmd.*;
+import bot.listener.JoinListener;
 import bot.listener.ReadyListener;
 import bot.service.UserService;
 import bot.task.StreakResetTask;
@@ -58,6 +59,7 @@ public class App implements ApplicationRunner {
     // Listeners
     static {
         listeners.add(new ReadyListener());
+        listeners.add(new JoinListener());
     }
 
     public void launch() {

--- a/app/src/main/java/bot/Constants.java
+++ b/app/src/main/java/bot/Constants.java
@@ -22,4 +22,9 @@ public class Constants {
     public static final int MIN_POINTS_FOR_STREAK = 20;
 
     public static final String DATABASE_NAME = "learn_english";
+
+    public static final Long MEMBER_ROLE_ID = 505348918520053760L;
+    // 505348918520053760L Member role id in the Official Learn English Server.
+    // 1120239610920976563L Member role id in the Learn English (Staging) Server.
+
 }

--- a/app/src/main/java/bot/listener/JoinListener.java
+++ b/app/src/main/java/bot/listener/JoinListener.java
@@ -18,7 +18,9 @@ public class JoinListener extends ListenerAdapter {
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
         User user = event.getUser();
         try {
-            Role role = event.getGuild().getRoleById(1120239610920976563L);
+            //505348918520053760L Member role id in the Official Learn English Server.
+            //1120239610920976563L Member role id in the Learn English (Staging) Server.
+            Role role = event.getGuild().getRoleById(505348918520053760L);
             if (role != null) {
                 // Assign the member role to the new user.
                 event.getGuild().addRoleToMember(user, role).queue();

--- a/app/src/main/java/bot/listener/JoinListener.java
+++ b/app/src/main/java/bot/listener/JoinListener.java
@@ -1,36 +1,40 @@
 package bot.listener;
 
+import bot.Constants;
+import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.apache.logging.log4j.Level;
 
 /**
  * @author Eaky0 A listener called whenever a user joins the guild. Mainly used for assigning
  *     initial roles such as 'Member'.
  */
+@Log4j2
 public class JoinListener extends ListenerAdapter {
-
     /**
      * @param event The event that takes place when a User/Member joins the guild.
      */
     @Override
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
-        User user = event.getUser();
         try {
-            // 505348918520053760L Member role id in the Official Learn English Server.
-            // 1120239610920976563L Member role id in the Learn English (Staging) Server.
-            Role role = event.getGuild().getRoleById(505348918520053760L);
+            User user = event.getUser();
+            Role role = event.getGuild().getRoleById(Constants.MEMBER_ROLE_ID);
             if (role != null) {
                 // Assign the member role to the new user.
                 event.getGuild().addRoleToMember(user, role).queue();
+
+                String logNote = "Successfully assigned the member role to " + user.getName() + "!";
+                log.log(Level.INFO, logNote);
+
             } else {
                 throw new NullPointerException();
             }
 
         } catch (NullPointerException e) {
-            System.out.println("This role doesn't exist!");
-            return;
+            log.error("Role doesn't exist!");
         }
     }
 }

--- a/app/src/main/java/bot/listener/JoinListener.java
+++ b/app/src/main/java/bot/listener/JoinListener.java
@@ -18,8 +18,8 @@ public class JoinListener extends ListenerAdapter {
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
         User user = event.getUser();
         try {
-            //505348918520053760L Member role id in the Official Learn English Server.
-            //1120239610920976563L Member role id in the Learn English (Staging) Server.
+            // 505348918520053760L Member role id in the Official Learn English Server.
+            // 1120239610920976563L Member role id in the Learn English (Staging) Server.
             Role role = event.getGuild().getRoleById(505348918520053760L);
             if (role != null) {
                 // Assign the member role to the new user.

--- a/app/src/main/java/bot/listener/JoinListener.java
+++ b/app/src/main/java/bot/listener/JoinListener.java
@@ -1,0 +1,34 @@
+package bot.listener;
+
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+/**
+ * @author Eaky0 A listener called whenever a user joins the guild. Mainly used for assigning
+ *     initial roles such as 'Member'.
+ */
+public class JoinListener extends ListenerAdapter {
+
+    /**
+     * @param event The event that takes place when a User/Member joins the guild.
+     */
+    @Override
+    public void onGuildMemberJoin(GuildMemberJoinEvent event) {
+        User user = event.getUser();
+        try {
+            Role role = event.getGuild().getRoleById(1120239610920976563L);
+            if (role != null) {
+                // Assign the member role to the new user.
+                event.getGuild().addRoleToMember(user, role).queue();
+            } else {
+                throw new NullPointerException();
+            }
+
+        } catch (NullPointerException e) {
+            System.out.println("This role doesn't exist!");
+            return;
+        }
+    }
+}

--- a/app/src/main/java/bot/listener/JoinListener.java
+++ b/app/src/main/java/bot/listener/JoinListener.java
@@ -2,11 +2,11 @@ package bot.listener;
 
 import bot.Constants;
 import lombok.extern.log4j.Log4j2;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.apache.logging.log4j.Level;
 
 /**
  * @author Eaky0 A listener called whenever a user joins the guild. Mainly used for assigning
@@ -19,22 +19,26 @@ public class JoinListener extends ListenerAdapter {
      */
     @Override
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
-        try {
-            User user = event.getUser();
-            Role role = event.getGuild().getRoleById(Constants.MEMBER_ROLE_ID);
-            if (role != null) {
-                // Assign the member role to the new user.
-                event.getGuild().addRoleToMember(user, role).queue();
+        Guild guild = event.getGuild();
+        User user = event.getUser();
+        Role role = guild.getRoleById(Constants.MEMBER_ROLE_ID);
 
-                String logNote = "Successfully assigned the member role to " + user.getName() + "!";
-                log.log(Level.INFO, logNote);
-
-            } else {
-                throw new NullPointerException();
-            }
-
-        } catch (NullPointerException e) {
-            log.error("Role doesn't exist!");
+        if (role == null) {
+            log.warn("Role ID (%s) does not match to the member role!");
+            return;
         }
+
+        if (event.getMember().getRoles().contains(role)) {
+            String message =
+                    String.format(
+                            "Member %s (ID: %s) already seems to have the member role.",
+                            user.getName(), user.getId());
+
+            log.info(message);
+            return;
+        }
+
+        // Assign the member role to the new user.
+        guild.addRoleToMember(user, role).queue();
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] All of the code is easily understood.
- [x] There is no redundant or duplicate code.

## Describe your changes
- **JoinListener**: Added a new class within the bot.listener package. Currently, It only assigns the 'Member' role for new members who have just joined the server. Note: I couldn't test this functionality, as I have no clue on how to use the docker container. 
I have tried this command ```docker run -it -p 27017:27017 --name mongoContainer mongo:latest```, but it didn't work.
- **App**: I added a new JoinListener object in the listeners list in the App class (where the main function resides). 

## Issue number
Atakan here, no Idea what the issue number for this, is supposed to be. I couldn't find this anywhere for this specific problem 😅.